### PR TITLE
Exit after printing version or usage

### DIFF
--- a/pcalc.y
+++ b/pcalc.y
@@ -318,7 +318,6 @@ static void print_usage(void)
 static void print_version(void)
 {
 	puts("Programmer's calculator by Peter Glen & Mike Frysinger. Version " VERSION);
-	exit(0);
 }
 
 int parse_comline(int argc, char *argv[])
@@ -329,8 +328,11 @@ int parse_comline(int argc, char *argv[])
 		switch (o) {
 		case 'h':
 			print_usage();
+			exit(0);
+
 		case 'v':
 			print_version();
+		        exit(0);
 
 		case 'n':	/* nibble mode */
 			fNibble = true;


### PR DESCRIPTION
Hello,
After printing the usage, I saw that pcalc also prints the version information, which in general is not necessary (as the command didn't ask for it). This PR addresses the fall-through that happens at line `330` and line `332` in `pcalc.y`.