### PR TITLE
fix failings builds in GCC15+ compilers

### DIFF
--- a/pcalc.y
+++ b/pcalc.y
@@ -96,10 +96,10 @@ list:
         ;
 
 
-junk:       IBUILTIN str            { (*($1->u.iptr))($2->u.str) ; }
+junk:       IBUILTIN str            { (*($1->u.iptr.func_str))($2->u.str) ; }
         |   IBUILTIN                { }
-        |   IBUILTIN VAR            { (*($1->u.iptr))($2->u.val) ; }
-        |   IBUILTIN expr           { (*($1->u.iptr))($2) ;       }
+        |   IBUILTIN VAR            { (*($1->u.iptr.func_dbl))($2->u.val) ; }
+        |   IBUILTIN expr           { (*($1->u.iptr.func_dbl))($2) ;       }
         |   STR                     { printf("%s", $1->name);}
         |   STRVAR                  { printf("%s", $1->u.str);}
         ;

--- a/symbol.c
+++ b/symbol.c
@@ -34,7 +34,7 @@ CONSTS consts[] =
 typedef struct
         {
         char     *name ;
-        long double (*func)();
+        long double (*func)(long double);
         }
         BUILTINS;
 
@@ -80,7 +80,7 @@ BUILTINS    builtins[] =
 typedef struct
         {
         char     *name ;
-        int      (*ifunc)() ;
+        IFUNC_UNION      ifunc ;
         }
         IBUILTINS;
 
@@ -88,19 +88,18 @@ IBUILTINS    ibuiltins[] =
 
 {
 
-        {"date",     ddate},
-        {"print",    print},
-        {"echo",     echo},
-        {"_echo",    echo_nl},
+    {"date",     {ddate}},
+    {"print",    {.func_dbl = print}},
+    {"echo",     {echo}},
+    {"_echo",    {echo_nl}},
 
-        {"DATE",     ddate},
-        {"PRINT",    print},
-        {"ECHO",     echo},
-        {"_ECHO",    echo_nl},
+    {"DATE",     {ddate}},
+    {"PRINT",    {.func_dbl = print}},
+    {"ECHO",     {echo}},
+    {"_ECHO",    {echo_nl}},
 
-        {NULL,       (void *) 0}
+    {nullptr,       {nullptr}}
 } ;
-
 
 
 void    init_sym(void)

--- a/symbol.c
+++ b/symbol.c
@@ -98,7 +98,7 @@ IBUILTINS    ibuiltins[] =
     {"ECHO",     {echo}},
     {"_ECHO",    {echo_nl}},
 
-    {nullptr,       {nullptr}}
+    {NULL,       (void *) 0}
 } ;
 
 

--- a/symbol.h
+++ b/symbol.h
@@ -3,6 +3,12 @@
 
 /* -------- Macros: ------------------------------------------------------ */
 
+typedef union
+{
+    int (*func_str)(const char*);
+    int (*func_dbl)(long double);
+} IFUNC_UNION;
+
 typedef struct Symbol {    /* symbol table entry */
          char *name ;
          short type ;      /* VAR, BLTIN, UNDEF  */
@@ -13,8 +19,8 @@ typedef struct Symbol {    /* symbol table entry */
                int    ival;               /* if VAR */
                long long  lval;           /* if VAR */
                long double val;           /* if VAR */
-               long double (*ptr)();      /* if BUILTIN */
-               int    (*iptr)();          /* if IBUILTIN */
+               long double (*ptr)(long double);      /* if BUILTIN */
+               IFUNC_UNION   iptr;          /* if IBUILTIN */
          } u ;
   struct Symbol *next ;
 } Symbol ;


### PR DESCRIPTION
  GCC15 compilers have become very strict in
  refusing situations that may lead to UB
  these include incompatible pointer conversions
  This fix attempts to make this code buildable under
  GCC versions 15 and beyond

fixes #17 